### PR TITLE
YAML_CPP_DLL is not correctly defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 
 if(WIN32)
 	if(BUILD_SHARED_LIBS)
-		add_definitions(-D${PROJECT_NAME}_DLL)	# use or build Windows DLL
+		add_definitions(-DYAML_CPP_DLL)	# use or build Windows DLL
 	endif()
 	if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 		set(CMAKE_INSTALL_PREFIX "C:/")


### PR DESCRIPTION
The CMakefile defines yaml-cpp_DLL instead of the expected YAML_CPP_DLL. YAML_CPP_DLL is needed to be defined to allow export of the symbols under MSVC.