### PR TITLE
yaml-cpp shared library is not installed under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,8 @@ write_basic_package_version_file(
 
 install(TARGETS yaml-cpp 
     EXPORT "${targets_export_name}"
-    INCLUDES DESTINATION "${include_install_dir}"
+	INCLUDES DESTINATION "${include_install_dir}"
+	RUNTIME DESTINATION ${LIB_INSTALL_DIR}
     LIBRARY DESTINATION ${lib_install_dir}
     ARCHIVE DESTINATION ${lib_install_dir}
     PUBLIC_HEADER DESTINATION ${include_install_dir}


### PR DESCRIPTION
yaml-cpp.dll is not being installed because the RUTIME installation is not in the list of artifacts to install. Problem described in issue #461